### PR TITLE
Colons in date values being incorrectly escaped

### DIFF
--- a/lib/parser_methods.rb
+++ b/lib/parser_methods.rb
@@ -84,7 +84,7 @@ module ActsAsSolr #:nodoc:
         end
         
         query_options[:field_list] = [field_list, 'score']
-        query = "(#{query.gsub(/ *: */,"_t:")}) #{models}"
+        query = "(" + query.gsub(/([a-z_][a-z0-9_]*) *: */,"\\1_t:") + ") #{models}"
         order = options[:order].split(/\s*,\s*/).collect{|e| e.gsub(/\s+/,'_t ').gsub(/\bscore_t\b/, 'score')  }.join(',') if options[:order] 
         query_options[:query] = replace_types([query])[0] # TODO adjust replace_types to work with String or Array  
 


### PR DESCRIPTION
Hi! I fixed a critical bug that prevents DateMath from parsing dates properly, because the colons in a date get escaped with _t.

Example:

created_at:[1976-03-06T23:59:59.999Z TO *] gets escaped to:

(created_at_t:[1976-03-06T23_t:59_t:59.999Z TO *]), which causes an error.

Now, it will properly escape:

(created_at_t:[1976-03-06T23:59:59.999Z TO *])
