### PR TITLE
Support namespaced models in solr search.

### DIFF
--- a/lib/parser_methods.rb
+++ b/lib/parser_methods.rb
@@ -103,8 +103,8 @@ module ActsAsSolr #:nodoc:
     end
     
     def solr_type_condition
-      subclasses.inject("(#{solr_configuration[:type_field]}:#{self.name}") do |condition, subclass|
-        condition << " OR #{solr_configuration[:type_field]}:#{subclass.name}"
+      subclasses.inject("(#{solr_configuration[:type_field]}:\"#{self.name}\"") do |condition, subclass|
+        condition << " OR #{solr_configuration[:type_field]}:\"#{subclass.name}\""
       end << ')'
     end
     


### PR DESCRIPTION
The current master at onemorecloud/acts_as_solr does not support namespaced models properly. The contents of the type field in the type condition need to be put into a separate string to prevent expressions like "type_s:Namespace::Model" which will cause crashes in solr. Instead, the current patch turns it into "type_s:\"Namespace::Model\"" which will work as designed.
